### PR TITLE
Null check empty cursor

### DIFF
--- a/android/src/main/java/com/calendarevents/CalendarEvents.java
+++ b/android/src/main/java/com/calendarevents/CalendarEvents.java
@@ -781,11 +781,13 @@ public class CalendarEvents extends ReactContextBaseJavaModule {
     private WritableNativeArray serializeEvents(Cursor cursor) {
         WritableNativeArray results = new WritableNativeArray();
 
-        while (cursor.moveToNext()) {
-            results.pushMap(serializeEvent(cursor));
-        }
+        if (cursor != null) {
+            while (cursor.moveToNext()) {
+                results.pushMap(serializeEvent(cursor));
+            }
 
-        cursor.close();
+            cursor.close();
+        }
 
         return results;
     }


### PR DESCRIPTION
Add a null check to cursor iteration as the absence of this causes crashes.

ContentResolver.query(...) can return null, see doc: https://developer.android.com/reference/android/content/ContentResolver.html#query(android.net.Uri,%20java.lang.String[],%20java.lang.String,%20java.lang.String[],%20java.lang.String)